### PR TITLE
일기 종류별 개수 조회 기능 추가

### DIFF
--- a/src/main/java/com/woozuda/backend/note/controller/NoteController.java
+++ b/src/main/java/com/woozuda/backend/note/controller/NoteController.java
@@ -1,13 +1,10 @@
 package com.woozuda.backend.note.controller;
 
 import com.woozuda.backend.account.dto.CustomUser;
-import com.woozuda.backend.note.dto.request.CommonNoteSaveRequestDto;
-import com.woozuda.backend.diary.dto.response.NoteIdResponseDto;
 import com.woozuda.backend.note.dto.request.NoteCondRequestDto;
 import com.woozuda.backend.note.dto.request.NoteIdRequestDto;
-import com.woozuda.backend.note.dto.request.QuestionNoteSaveRequestDto;
-import com.woozuda.backend.note.dto.request.RetrospectiveNoteSaveRequestDto;
 import com.woozuda.backend.note.dto.response.DateListResponseDto;
+import com.woozuda.backend.note.dto.response.NoteCountResponseDto;
 import com.woozuda.backend.note.dto.response.NoteEntryResponseDto;
 import com.woozuda.backend.note.service.NoteService;
 import jakarta.validation.Valid;
@@ -19,10 +16,12 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
 
 @RestController
 @RequestMapping("/api/note")
@@ -62,6 +61,17 @@ public class NoteController {
         String username = user.getUsername();
         noteService.deleteNotes(username, requestDto);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/count")
+    public ResponseEntity<NoteCountResponseDto> getNoteCount(
+            @AuthenticationPrincipal CustomUser user,
+            @RequestParam("startDate") LocalDate startDate,
+            @RequestParam("endDate") LocalDate endDate
+    ) {
+        String username = user.getUsername();
+        NoteCountResponseDto responseDto = noteService.getNoteCount(username, startDate, endDate);
+        return ResponseEntity.ok(responseDto);
     }
 
 }

--- a/src/main/java/com/woozuda/backend/note/dto/response/NoteCountResponseDto.java
+++ b/src/main/java/com/woozuda/backend/note/dto/response/NoteCountResponseDto.java
@@ -1,0 +1,15 @@
+package com.woozuda.backend.note.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class NoteCountResponseDto {
+
+    private Integer nonRetroCount;
+    private Integer retroCount;
+
+}

--- a/src/main/java/com/woozuda/backend/note/repository/CustomNoteRepository.java
+++ b/src/main/java/com/woozuda/backend/note/repository/CustomNoteRepository.java
@@ -3,9 +3,11 @@ package com.woozuda.backend.note.repository;
 import com.woozuda.backend.note.dto.request.NoteCondRequestDto;
 import com.woozuda.backend.note.dto.response.DateInfoResponseDto;
 import com.woozuda.backend.note.dto.response.DateListResponseDto;
+import com.woozuda.backend.note.dto.response.NoteCountResponseDto;
 import com.woozuda.backend.note.dto.response.NoteResponseDto;
 import com.woozuda.backend.note.entity.Note;
 
+import java.time.LocalDate;
 import java.util.List;
 
 //TODO search...Note() 메서드 공통: noteId 만으로 해당 노트가 로그인한 사용자의 것인지 보장할 수 없음 -> 추가 로직 구현
@@ -25,5 +27,6 @@ public interface CustomNoteRepository {
 
     List<DateInfoResponseDto> searchDateCounts(List<Long> idList);
 
+    NoteCountResponseDto searchNoteCount(List<Long> idList, LocalDate startDate, LocalDate endDate);
 }
 

--- a/src/main/java/com/woozuda/backend/note/service/NoteService.java
+++ b/src/main/java/com/woozuda/backend/note/service/NoteService.java
@@ -10,6 +10,7 @@ import com.woozuda.backend.note.dto.request.QuestionNoteSaveRequestDto;
 import com.woozuda.backend.note.dto.request.RetrospectiveNoteSaveRequestDto;
 import com.woozuda.backend.note.dto.response.DateInfoResponseDto;
 import com.woozuda.backend.note.dto.response.DateListResponseDto;
+import com.woozuda.backend.note.dto.response.NoteCountResponseDto;
 import com.woozuda.backend.note.dto.response.NoteEntryResponseDto;
 import com.woozuda.backend.note.dto.response.NoteResponseDto;
 import com.woozuda.backend.note.entity.CommonNote;
@@ -112,5 +113,11 @@ public class NoteService {
     public void deleteNotes(String username, NoteIdRequestDto requestDto) {
         List<Note> notesToDelete = noteRepository.findAllById(requestDto.getId());
         noteRepository.deleteAll(notesToDelete);
+    }
+
+    public NoteCountResponseDto getNoteCount(String username, LocalDate startDate, LocalDate endDate) {
+        List<Long> idList = diaryRepository.searchDiaryIdList(username);
+
+        return noteRepository.searchNoteCount(idList, startDate, endDate);
     }
 }


### PR DESCRIPTION
특정 날짜 구간에 작성한 자유일기와 오늘의 질문 일기 개수, 회고 개수를 조회하는 API를 추가했습니다.
`searchNoteCount()` 메서드를 보면 쿼리를 보내고 자바 코드 상에서 쿼리 결과를 dto 스펙에 맞게 가공하는 부분이 있는데, 이 부분을 없애고 한 방 쿼리로 해결할 수 있도록 추후 리팩토링할 계획입니다.