### PR TITLE
feat : 로그아웃 기능 추가

### DIFF
--- a/src/main/java/com/woozuda/backend/account/controller/LogoutController.java
+++ b/src/main/java/com/woozuda/backend/account/controller/LogoutController.java
@@ -1,0 +1,30 @@
+package com.woozuda.backend.account.controller;
+
+
+import com.woozuda.backend.account.service.LogoutService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/api/logout")
+@RequiredArgsConstructor
+@RestController
+public class LogoutController {
+
+    private final LogoutService logoutService;
+
+    @GetMapping("")
+    public ResponseEntity<Void> logout(){
+
+        ResponseCookie expiredCookie = logoutService.logout();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, expiredCookie.toString())
+                .build();
+    }
+}

--- a/src/main/java/com/woozuda/backend/account/service/LogoutService.java
+++ b/src/main/java/com/woozuda/backend/account/service/LogoutService.java
@@ -1,0 +1,28 @@
+package com.woozuda.backend.account.service;
+
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Service;
+
+@Service
+public class LogoutService {
+
+    public ResponseCookie logout(){
+
+        ResponseCookie expiredCookie = createCookie("Authorization", "");
+        return expiredCookie;
+    }
+
+    private ResponseCookie createCookie(String key, String value) {
+
+        ResponseCookie responseCookie = ResponseCookie.from(key, value)
+                .httpOnly(false)
+                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+        return responseCookie;
+    }
+}


### PR DESCRIPTION
프론트에서 도메인이 안맞아서 쿠키 삭제가 안되신대서

조금 부자연스럽지만 -- 이렇게 구현하는 블로그를 못보긴 했네요 . 
제가 쿠키의 age(expire값) 을 임의로 0으로 수정시켜서 덮어쓰는 방식으로 쿠키를 만료 시킵니다. 