### PR TITLE
feat: aop(시간 측정) 어노테이션 제작

### DIFF
--- a/src/main/java/com/woozuda/backend/account/controller/AdminController.java
+++ b/src/main/java/com/woozuda/backend/account/controller/AdminController.java
@@ -1,6 +1,7 @@
 package com.woozuda.backend.account.controller;
 
 
+import com.woozuda.backend.aop.LogExecutionTime;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -12,6 +13,7 @@ public class AdminController {
         return "admin controller";
     }
 
+    @LogExecutionTime
     @GetMapping("/account/sample/alluser")
     public String allP(){
         return "all user can access this page!";
@@ -19,5 +21,4 @@ public class AdminController {
 
     @GetMapping("/account/sample/user")
     public String userP(){ return "user can access this page! ";}
-
 }

--- a/src/main/java/com/woozuda/backend/aop/LogExecutionTime.java
+++ b/src/main/java/com/woozuda/backend/aop/LogExecutionTime.java
@@ -1,0 +1,11 @@
+package com.woozuda.backend.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface LogExecutionTime {
+}

--- a/src/main/java/com/woozuda/backend/aop/LogExecutionTimeAspect.java
+++ b/src/main/java/com/woozuda/backend/aop/LogExecutionTimeAspect.java
@@ -1,0 +1,25 @@
+package com.woozuda.backend.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@Slf4j
+public class LogExecutionTimeAspect {
+
+    @Around("@annotation(com.woozuda.backend.aop.LogExecutionTime)")
+    public void logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
+        long start = System.currentTimeMillis();
+
+        // 실제 메서드 실행
+        joinPoint.proceed();
+
+        long executionTime = System.currentTimeMillis() - start;
+        log.info("[LogExecutionTime] {} executed in {} ms",
+                joinPoint.getSignature(), executionTime);
+    }
+}


### PR DESCRIPTION
운영중에 실행시간이 늦은 api 의 경우 어느 메서드에서 시간이 많이 걸리는지 추적하기 위한 커스텀 어노테이션을 제작했습니다.
다음과 같이 어노테이션을 붙이면 자동으로 시간을 측정해 줍니다.
대략적인 원인 파악 및 검증에는 쓸만 할 거 같네요 ...

<img width="583" alt="image" src="https://github.com/user-attachments/assets/a69c1da4-1704-4704-aebb-b1694f0b5e35" />

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/41ed3a85-a424-42f7-9320-ef8e6e17d58d" />

참고) aop가 프록시 기반으로 구축이 되어 있어  @Service, @Component, @Controller 와 같이 스프링 빈(bean) 으로 등록된 것만 추적이 가능합니다.
<img width="797" alt="image" src="https://github.com/user-attachments/assets/96ebbc84-70b8-4174-86ad-9ebe4280d983" />