### PR TITLE
image 삭제 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,9 @@ dependencies {
 
 	//OpenFeign: 외부 API 사용
 	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign:4.1.4'
+
+	// html 파싱을 위한 jsoup
+	implementation 'org.jsoup:jsoup:1.16.1'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/woozuda/backend/diary/service/DiaryService.java
+++ b/src/main/java/com/woozuda/backend/diary/service/DiaryService.java
@@ -11,6 +11,8 @@ import com.woozuda.backend.diary.dto.response.DiaryNameResponseDto;
 import com.woozuda.backend.diary.dto.response.SingleDiaryResponseDto;
 import com.woozuda.backend.diary.entity.Diary;
 import com.woozuda.backend.diary.repository.DiaryRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.image.type.ImageType;
 import com.woozuda.backend.note.dto.request.NoteCondRequestDto;
 import com.woozuda.backend.note.dto.response.NoteEntryResponseDto;
 import com.woozuda.backend.note.dto.response.NoteResponseDto;
@@ -40,6 +42,7 @@ public class DiaryService {
     private final UserRepository userRepository;
     private final TagRepository tagRepository;
     private final NoteRepository noteRepository;
+    private final ImageService imageService;
 
     @Transactional(readOnly = true)
     public DiaryListResponseDto getDairyList(String username) {
@@ -100,6 +103,10 @@ public class DiaryService {
         }
 
         Diary savedDiary = diaryRepository.save(diary);
+
+        // 이미지 테이블 변경(다이어리 생성 시)
+        imageService.afterCreate(ImageType.DIARY, savedDiary.getId(), requestDto.getImgUrl());
+
         return new DiaryIdResponseDto(savedDiary.getId());
     }
 
@@ -122,6 +129,9 @@ public class DiaryService {
             diary.change(requestDto.getTitle(), tags, requestDto.getImgUrl());
         }
 
+        // 이미지 테이블 반영 (다이어리 변경 시)
+        imageService.afterUpdate(ImageType.DIARY, diaryId, requestDto.getImgUrl());
+
         return new DiaryIdResponseDto(foundDiary.get().getId());
     }
 
@@ -133,6 +143,9 @@ public class DiaryService {
         if (!diary.getUser().getUsername().equals(username)) {
             throw new IllegalArgumentException("This diary does not belong to the user.");
         }
+
+        // 이미지 테이블 반영 (다이어리 삭제 시)
+        imageService.afterDelete(ImageType.DIARY, diaryId);
 
         diaryRepository.deleteById(diaryId);
     }

--- a/src/main/java/com/woozuda/backend/image/controller/ImageController.java
+++ b/src/main/java/com/woozuda/backend/image/controller/ImageController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @RequestMapping("/api/image")
 @RequiredArgsConstructor
@@ -27,6 +28,14 @@ public class ImageController {
         ImageDto responseDto = imageService.uploadImage(multipartFile);
         return ResponseEntity.ok(responseDto);
     }
+
+    /*
+    @PostMapping("/delete")
+    public void deleteImage(){
+        String url = "https://kr.object.ncloudstorage.com/woozuda-image/test-dummy.png";
+        imageService.deleteImage(url.split("/")[4]);
+    }
+    */
 
     // 랜덤 이미지 추출
     @GetMapping("/random")

--- a/src/main/java/com/woozuda/backend/image/cron/ImageDeleteTask.java
+++ b/src/main/java/com/woozuda/backend/image/cron/ImageDeleteTask.java
@@ -1,0 +1,36 @@
+package com.woozuda.backend.image.cron;
+
+import com.woozuda.backend.image.entity.Image;
+import com.woozuda.backend.image.repository.ImageRepository;
+import com.woozuda.backend.image.service.ImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Component
+public class ImageDeleteTask {
+
+    private final ImageService imageService;
+    private final ImageRepository imageRepository;
+
+    @Scheduled(cron = "0 0 3 * * *") // 매일 오전 3시
+    public void cleanUpImages() {
+        // 게시물과 연결되지 않은 이미지 조회
+        List<Image> deleteImages = imageRepository.findByIsLinkedToPost(false);
+        List<Long> deleteImageIds = new ArrayList<>();
+
+        // 해당 이미지 object storage 에서 삭제
+        for(Image deleteImage : deleteImages){
+            // 지울 이미지들의 Id 추가 (db 에도 반영 위해서)
+            deleteImageIds.add(deleteImage.getId());
+            imageService.deleteImage(deleteImage.getImageUrl().split("/")[4]);
+        }
+
+        // db(이미지 테이블) 도 그에 맞추어 삭제
+        imageRepository.deleteAllById(deleteImageIds);
+    }
+}

--- a/src/main/java/com/woozuda/backend/image/entity/Image.java
+++ b/src/main/java/com/woozuda/backend/image/entity/Image.java
@@ -2,11 +2,10 @@ package com.woozuda.backend.image.entity;
 
 
 import com.woozuda.backend.global.entity.BaseTimeEntity;
+import com.woozuda.backend.image.type.ImageType;
 import jakarta.persistence.*;
 import lombok.Getter;
-import lombok.Setter;
 
-@Setter
 @Getter
 @Entity
 @Table(name="image")
@@ -23,12 +22,30 @@ public class Image extends BaseTimeEntity {
     @Column(name = "is_linked_to_post")
     private Boolean isLinkedToPost;
 
-    public Image(String imageUrl, Boolean isLinkedToPost) {
+    @Column(name = "image_type")
+    private ImageType imageType;
+
+    @Column(name = "connected_id")
+    private Long connectedId;
+
+    private Image(String imageUrl, Boolean isLinkedToPost) {
         this.imageUrl = imageUrl;
         this.isLinkedToPost = isLinkedToPost;
     }
 
     public static Image of(String imageUrl, Boolean isLinkedToPost) {
         return new Image(imageUrl, isLinkedToPost);
+    }
+
+    public void changeLinkedToPost(Boolean isLinkedToPost) {
+        this.isLinkedToPost = isLinkedToPost;
+    }
+
+    public void changeImageType(ImageType imageType){
+        this.imageType = imageType;
+    }
+
+    public void changeConectedId(Long connectedId){
+        this.connectedId = connectedId;
     }
 }

--- a/src/main/java/com/woozuda/backend/image/repository/ImageRepository.java
+++ b/src/main/java/com/woozuda/backend/image/repository/ImageRepository.java
@@ -1,7 +1,18 @@
 package com.woozuda.backend.image.repository;
 
 import com.woozuda.backend.image.entity.Image;
+import com.woozuda.backend.image.type.ImageType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image,Long> {
+
+    // ImageType 과 ConnectedId 가 일치하는 이미지를 찾는 쿼리
+    public List<Image> findByImageTypeAndConnectedId(ImageType imageType, Long connectedId);
+
+    // imageUrl이 일치하는 이미지를 찾는 쿼리 (select * from image where image_url IN (image_url1 , image_url2 , ....)
+    public List<Image> findByImageUrlIn(List<String> imageUrls);
+
+    public Image findByImageUrl(String imageUrl);
 }

--- a/src/main/java/com/woozuda/backend/image/repository/ImageRepository.java
+++ b/src/main/java/com/woozuda/backend/image/repository/ImageRepository.java
@@ -14,5 +14,8 @@ public interface ImageRepository extends JpaRepository<Image,Long> {
     // imageUrl이 일치하는 이미지를 찾는 쿼리 (select * from image where image_url IN (image_url1 , image_url2 , ....)
     public List<Image> findByImageUrlIn(List<String> imageUrls);
 
+    // isLinkedToPost 가 true/false 인 이미지 찾기.
+    public List<Image> findByIsLinkedToPost(Boolean isLinkedToPost);
+
     public Image findByImageUrl(String imageUrl);
 }

--- a/src/main/java/com/woozuda/backend/image/service/ImageService.java
+++ b/src/main/java/com/woozuda/backend/image/service/ImageService.java
@@ -75,6 +75,11 @@ public class ImageService {
         return new ImageDto(imgUrl);
     }
 
+    public void deleteImage(String filename){
+        AmazonS3 s3 = s3Client.getAmazonS3();
+        s3.deleteObject(s3Client.getBucketName(), filename);
+    }
+
     // urlContent 를 가공해주는 메서드
     public List<String> makeImgsUrl(ImageType imageType, String urlContent){
 

--- a/src/main/java/com/woozuda/backend/image/service/ImageService.java
+++ b/src/main/java/com/woozuda/backend/image/service/ImageService.java
@@ -10,24 +10,34 @@ import com.woozuda.backend.image.config.S3Client;
 import com.woozuda.backend.image.dto.ImageDto;
 import com.woozuda.backend.image.entity.Image;
 import com.woozuda.backend.image.repository.ImageRepository;
+import com.woozuda.backend.image.type.ImageType;
+import jakarta.persistence.Column;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
+@Slf4j
 public class ImageService {
 
     private final S3Client s3Client;
     private final ImageRepository imageRepository;
 
 
-
-    @Transactional
     public ImageDto uploadImage(MultipartFile multipartFile) throws IOException {
 
         // 올릴 이미지가 첨부되지 않았을 경우
@@ -39,6 +49,9 @@ public class ImageService {
 
         // 파일 이름 추출
         String filename = multipartFile.getOriginalFilename();
+        String uuid = UUID.randomUUID().toString();
+        filename = uuid + "_" +filename;
+
         String bucketname = s3Client.getBucketName();
 
         // 메타데이터 생성
@@ -62,7 +75,104 @@ public class ImageService {
         return new ImageDto(imgUrl);
     }
 
-    @Transactional
+    // urlContent 를 가공해주는 메서드
+    public List<String> makeImgsUrl(ImageType imageType, String urlContent){
+
+        List<String> imgs = new ArrayList<>();
+
+        if(imageType == ImageType.NOTE){
+            // Note는 content가 <p> 안녕하세요 </p> <img src ="https://~~> 처럼 되어 있어서 파싱 해야함
+            Document doc = Jsoup.parse(urlContent);
+            Elements imgTags = doc.select("img");
+
+            for(Element img: imgTags){
+                imgs.add(img.attr("src"));
+            }
+        }else if(imageType == ImageType.DIARY) {
+            //다이어리 같은 경우에는 imgUrl 이 바로 들어있어서 배열에 넣기만 하면 됨
+            imgs.add(urlContent);
+        }
+
+        return imgs;
+    }
+
+    // 다이어리 - 랜덤 이미지 생성 (기본 이미지 10장) 은 연산에서 제외 되어야 함 - 기본 제공 이미지들.
+    // 현재 기본 이미지가 이미지 테이블에 저장되지는 않았으나, 혹시 모를 변수(프론트의 약간의 착오 등...) 를 위해 예외 처리 합니다.
+    public List<String> excludeBasicImage(List<String> imageStrings){
+        imageStrings.removeIf(image -> image.startsWith("https://kr.object.ncloudstorage.com/woozuda-image/random-image"));
+        return imageStrings;
+    }
+
+    public void afterCreate(ImageType imageType, Long connectedId, String content){
+        //content에서 imageUrl 추출( 리스트로 변환)
+        List<String> imagesUrl = makeImgsUrl(imageType, content);
+
+        //기본 이미지 - 주어지는 default 이미지는 제외 (필수는 아니나 혹시 해서 넣어둔 로직)
+        imagesUrl = excludeBasicImage(imagesUrl);
+
+        List<Image> images = imageRepository.findByImageUrlIn(imagesUrl);
+
+        // 영속 상태의 엔티티라 save() 하지 않아도 반영됨
+        for(Image image : images){
+            image.changeLinkedToPost(true);
+            image.changeImageType(imageType);
+            image.changeConectedId(connectedId);
+        }
+    }
+
+    public void afterUpdate(ImageType imageType, Long connectedId, String content){
+
+        List<String> imagesUrl = makeImgsUrl(imageType, content);
+
+        //기본 이미지 - 주어지는 default 이미지는 제외 (필수는 아니나 혹시 해서 넣어둔 로직)
+        imagesUrl = excludeBasicImage(imagesUrl);
+
+        // 이번에 업데이트할 글에 저장되어있는 그림들 리스트
+        List<Image> afterImages = imageRepository.findByImageUrlIn(imagesUrl);
+        boolean[] afterImagesBool = new boolean[afterImages.size()];
+
+        //기존에 글(다이어리)에 저장되어있던 그림들을 불러옴
+        List<Image> beforeImages = imageRepository.findByImageTypeAndConnectedId(imageType, connectedId);
+        boolean[] beforeImagesBool = new boolean[beforeImages.size()];
+
+        //수정 전과 수정 후에 둘다 있는 이미지는 true 처리 - 그리고 이 이미지들은 수정할 필요 없음.
+        for(int i=0; i < beforeImages.size(); i++){
+            for(int j=0; j < afterImages.size(); j++) {
+                if (beforeImages.get(i).getImageUrl().equals(afterImages.get(j).getImageUrl())) {
+                    beforeImagesBool[i] = true;
+                    afterImagesBool[j] = true;
+                }
+            }
+        }
+
+        // 수정 전 이미지 리스트 중 false 인 것들은 이번에 수정되면서 삭제된 이미지 임 - 고로 삭제 처리 해줘야 함
+        List<Long> deleteImagesId = new ArrayList<>();
+        for(int i=0; i < beforeImages.size(); i++){
+            if(!beforeImagesBool[i]){
+                deleteImagesId.add(beforeImages.get(i).getId());
+            }
+        }
+        imageRepository.deleteAllById(deleteImagesId);
+
+        // 수정 후 이미지 리스트 중 false 인 것들은 이번에 수정되면서 추가된 이미지 임 - 고로 추가 처리 해줘야 함
+        for(int j=0; j < afterImages.size(); j++){
+            if(!afterImagesBool[j]){
+                Image nowImage = afterImages.get(j);
+
+                nowImage.changeLinkedToPost(true);
+                nowImage.changeImageType(imageType);
+                nowImage.changeConectedId(connectedId);
+            }
+        }
+
+    }
+
+    public void afterDelete(ImageType imageType, Long connectedId){
+        List<Image> images = imageRepository.findByImageTypeAndConnectedId(imageType, connectedId);
+        imageRepository.deleteAll(images);
+    }
+
+    @Transactional(readOnly = true)
     public ImageDto getRandomImage() {
         Random random = new Random();
         int imageNumber = random.nextInt(10) + 1;

--- a/src/main/java/com/woozuda/backend/image/type/ImageType.java
+++ b/src/main/java/com/woozuda/backend/image/type/ImageType.java
@@ -1,0 +1,6 @@
+package com.woozuda.backend.image.type;
+
+public enum ImageType {
+    DIARY,
+    NOTE
+}

--- a/src/main/java/com/woozuda/backend/note/service/CommonNoteService.java
+++ b/src/main/java/com/woozuda/backend/note/service/CommonNoteService.java
@@ -4,6 +4,8 @@ import com.woozuda.backend.alarm.service.AlarmService;
 import com.woozuda.backend.diary.dto.response.NoteIdResponseDto;
 import com.woozuda.backend.diary.entity.Diary;
 import com.woozuda.backend.diary.repository.DiaryRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.image.type.ImageType;
 import com.woozuda.backend.note.dto.request.CommonNoteModifyRequestDto;
 import com.woozuda.backend.note.dto.request.CommonNoteSaveRequestDto;
 import com.woozuda.backend.note.dto.response.NoteResponseDto;
@@ -33,6 +35,7 @@ public class CommonNoteService {
     private final NoteRepository noteRepository;
     private final DiaryRepository diaryRepository;
     private final AlarmService alarmService;
+    private final ImageService imageService;
 
     public NoteIdResponseDto saveCommonNote(String username, CommonNoteSaveRequestDto requestDto) {
         Diary foundDiary = diaryRepository.searchDiary(requestDto.getDiaryId(), username);
@@ -56,6 +59,9 @@ public class CommonNoteService {
 
         // 이번에 저장한 자유일기가 그 주의 3번째 일기라면(자유일기 + 질문일기 기준), 알람을 발생합니다.
         alarmService.threePostAlarm(username, requestDto.getDate());
+
+        // 이미지 테이블 반영 (자유일기 생성 후)
+        imageService.afterCreate(ImageType.NOTE, savedCommonNote.getId(), requestDto.getContent());
 
         return NoteIdResponseDto.of(savedCommonNote.getId());
     }
@@ -84,6 +90,9 @@ public class CommonNoteService {
                 LocalDate.parse(requestDto.getDate()),
                 requestDto.getContent()
         );
+
+        // 이미지 테이블 반영 (자유일기 변경 후)
+        imageService.afterUpdate(ImageType.NOTE, noteId, requestDto.getContent());
 
         return NoteIdResponseDto.of(foundNote.getId());
     }

--- a/src/main/java/com/woozuda/backend/note/service/NoteService.java
+++ b/src/main/java/com/woozuda/backend/note/service/NoteService.java
@@ -2,6 +2,8 @@ package com.woozuda.backend.note.service;
 
 import com.woozuda.backend.diary.entity.Diary;
 import com.woozuda.backend.diary.repository.DiaryRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.image.type.ImageType;
 import com.woozuda.backend.note.dto.request.NoteCondRequestDto;
 import com.woozuda.backend.note.dto.request.NoteIdRequestDto;
 import com.woozuda.backend.note.dto.response.DateInfoResponseDto;
@@ -33,6 +35,7 @@ public class NoteService {
 
     private final NoteRepository noteRepository;
     private final DiaryRepository diaryRepository;
+    private final ImageService imageService;
 
     /**
      * 최신순 일기 조회
@@ -105,6 +108,15 @@ public class NoteService {
         for (Diary diary : diariesToChange) {
             diary.updateNoteInfo(requestDto.getId());
         }
+
+
+        //해당 노트에 써있던 이미지들 삭제
+        List<Long> deleteNoteIds = requestDto.getId();
+
+        for(Long deleteNoteId : deleteNoteIds){
+            imageService.afterDelete(ImageType.NOTE, deleteNoteId);
+        }
+
     }
 
     public NoteCountResponseDto getNoteCount(String username, LocalDate startDate, LocalDate endDate) {

--- a/src/main/java/com/woozuda/backend/note/service/QuestionNoteService.java
+++ b/src/main/java/com/woozuda/backend/note/service/QuestionNoteService.java
@@ -4,6 +4,8 @@ import com.woozuda.backend.alarm.service.AlarmService;
 import com.woozuda.backend.diary.dto.response.NoteIdResponseDto;
 import com.woozuda.backend.diary.entity.Diary;
 import com.woozuda.backend.diary.repository.DiaryRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.image.type.ImageType;
 import com.woozuda.backend.note.dto.request.QuestionNoteModifyRequestDto;
 import com.woozuda.backend.note.dto.request.QuestionNoteSaveRequestDto;
 import com.woozuda.backend.note.dto.response.NoteResponseDto;
@@ -35,6 +37,7 @@ public class QuestionNoteService {
     private final DiaryRepository diaryRepository;
     private final QuestionRepository questionRepository;
     private final AlarmService alarmService;
+    private final ImageService imageService;
 
     public NoteIdResponseDto saveQuestionNote(String username, QuestionNoteSaveRequestDto requestDto) {
         Diary foundDiary = diaryRepository.searchDiary(requestDto.getDiaryId(), username);
@@ -63,6 +66,9 @@ public class QuestionNoteService {
         // 이번에 저장한 질문일기가 그 주의 3번째 일기라면(자유일기 + 질문일기 기준), 알람을 발생합니다.
         alarmService.threePostAlarm(username, requestDto.getDate());
 
+        // 이미지 테이블 반영 (질문 일기 생성 후)
+        imageService.afterCreate(ImageType.NOTE, savedQuestionNote.getId(), requestDto.getContent());
+
         return NoteIdResponseDto.of(savedQuestionNote.getId());
     }
 
@@ -89,6 +95,9 @@ public class QuestionNoteService {
                 LocalDate.parse(requestDto.getDate()),
                 requestDto.getContent()
         );
+
+        // 이미지 테이블 반영 (질문 일기 변경 후)
+        imageService.afterUpdate(ImageType.NOTE, noteId, requestDto.getContent());
 
         return NoteIdResponseDto.of(foundNote.getId());
     }

--- a/src/test/java/com/woozuda/backend/image/ImageDeleteCronTest.java
+++ b/src/test/java/com/woozuda/backend/image/ImageDeleteCronTest.java
@@ -1,0 +1,64 @@
+package com.woozuda.backend.image;
+
+import com.woozuda.backend.image.config.S3Client;
+import com.woozuda.backend.image.cron.ImageDeleteTask;
+import com.woozuda.backend.image.entity.Image;
+import com.woozuda.backend.image.repository.ImageRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.note.entity.converter.AesEncryptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(ImageDeleteTask.class)
+public class ImageDeleteCronTest {
+
+    @MockBean
+    private AesEncryptor aesEncryptor;
+
+    @MockBean
+    private ImageService imageService;
+
+    @Autowired
+    private ImageDeleteTask imageDeleteTask;
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @BeforeEach
+    void setUp() {
+        imageRepository.deleteAll();
+
+        List<Image> images = new ArrayList<>();
+        images.add(Image.of("https://kr.object.ncloudstorage.com/test/aaa.com", false));
+        images.add(Image.of("https://kr.object.ncloudstorage.com/test/bbb.com", true));
+        images.add(Image.of("https://kr.object.ncloudstorage.com/test/ccc.com", false));
+        images.add(Image.of("https://kr.object.ncloudstorage.com/test/ddd.com", true));
+        images.add(Image.of("https://kr.object.ncloudstorage.com/test/eee.com", false));
+
+        imageRepository.saveAll(images);
+    }
+
+    @Test
+    void 크론잡_테스트() {
+        //when
+        imageDeleteTask.cleanUpImages();
+
+        //then
+        assertThat(imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/test/aaa.com")).isEqualTo(null);
+        assertThat(imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/test/ccc.com")).isEqualTo(null);
+        assertThat(imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/test/eee.com")).isEqualTo(null);
+
+        assertThat(imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/test/bbb.com").getIsLinkedToPost()).isEqualTo(true);
+        assertThat(imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/test/ddd.com").getIsLinkedToPost()).isEqualTo(true);
+    }
+}

--- a/src/test/java/com/woozuda/backend/image/ImageServiceTest.java
+++ b/src/test/java/com/woozuda/backend/image/ImageServiceTest.java
@@ -1,0 +1,407 @@
+package com.woozuda.backend.image;
+
+import com.woozuda.backend.image.config.S3Client;
+import com.woozuda.backend.image.entity.Image;
+import com.woozuda.backend.image.repository.ImageRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.image.type.ImageType;
+import com.woozuda.backend.note.entity.converter.AesEncryptor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(ImageService.class)
+public class ImageServiceTest {
+
+    @MockBean
+    private AesEncryptor aesEncryptor;
+
+    @MockBean
+    private S3Client s3Client;
+
+    @Autowired
+    private ImageService imageService;
+
+    @Autowired
+    private ImageRepository imageRepository;
+
+    @BeforeEach
+    void setUp(){
+       imageRepository.deleteAll();
+
+       List<Image> images = new ArrayList<>();
+       images.add(Image.of("https://aaa.com", false));
+       images.add(Image.of("https://bbb.com", false));
+       images.add(Image.of("https://ccc.com", false));
+       images.add(Image.of("https://ddd.com", false));
+       images.add(Image.of("https://eee.com", false));
+
+       imageRepository.saveAll(images);
+    }
+    // 테스트 해야 할 것
+    // 1. 다이어리 / 일기의 생성
+    @Test
+    void 기본이미지_다이어리_생성() {
+
+        // when (랜덤 이미지로 다이어리 생성)
+        imageService.afterCreate(ImageType.DIARY, 1L, "https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+
+        // then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 커스텀이미지_다이어리_생성(){
+        // when (aaa.com 이라는 커스텀 이미지로 다이어리를 생성했다면)
+        imageService.afterCreate(ImageType.DIARY, 3L, "https://aaa.com");
+
+        // then
+        //aaa.com 은 true 가 되어야 함
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getConnectedId()).isEqualTo(3L);
+        assertThat(tempImage1.getImageType()).isEqualTo(ImageType.DIARY);
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(true);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 이미지_없는_일기_생성(){
+        // when (aaa.com 이라는 커스텀 이미지로 다이어리를 생성했다면)
+        imageService.afterCreate(ImageType.NOTE, 3L, "<a> 하하하 </a> <p> 나는 p 에요 </p> <h2> 하하하 </h2> <h1> 나는 제목이에요 </h1>");
+
+        // then
+        //aaa.com 은 true 가 되어야 함
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 이미지_있는_일기_생성(){
+        // when (aaa.com 이라는 커스텀 이미지로 다이어리를 생성했다면)
+        imageService.afterCreate(ImageType.NOTE, 3L, "<a> 하하하 </a> <p> 나는 p 에요 </p> <img src=\"https://aaa.com\"> <h1> 나는 제목이에요 </h1>");
+
+        // then
+        //aaa.com 은 true 가 되어야 함
+
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getConnectedId()).isEqualTo(3L);
+        assertThat(tempImage1.getImageType()).isEqualTo(ImageType.NOTE);
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(true);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    //2. 다이어리 / 일기의 수정
+    @Test
+    void 다이어리_기본이미지에서_기본이미지로_수정(){
+        //when
+        imageService.afterUpdate(ImageType.DIARY, 1L, "https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 다이어리_기본이미지에서_커스텀이지미지로_수정(){
+        //when
+        imageService.afterUpdate(ImageType.DIARY, 3L, "https://aaa.com");
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getConnectedId()).isEqualTo(3L);
+        assertThat(tempImage1.getImageType()).isEqualTo(ImageType.DIARY);
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(true);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 다이어리_커스텀이미지에서_기본이미지로_수정(){
+        //given ( 기존 다이어리는 id 가 3이고, aaa.com 을 표지로 한다고 가정)
+
+        Image prevImage = imageRepository.findByImageUrl("https://aaa.com");
+        prevImage.changeImageType(ImageType.DIARY);
+        prevImage.changeConectedId(3L);
+        prevImage.changeLinkedToPost(true);
+
+        //when
+        imageService.afterUpdate(ImageType.DIARY, 3L, "https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1).isEqualTo(null);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 일기_수정(){
+        //given ( 기존 일기장 id 가 3이고, aaa.com , ccc.com 을 가지고 있던 일기 라고 가정)
+        Image prevImage = imageRepository.findByImageUrl("https://aaa.com");
+        prevImage.changeImageType(ImageType.NOTE);
+        prevImage.changeConectedId(3L);
+        prevImage.changeLinkedToPost(true);
+
+        Image prevImage2 = imageRepository.findByImageUrl("https://ccc.com");
+        prevImage.changeImageType(ImageType.NOTE);
+        prevImage.changeConectedId(3L);
+        prevImage.changeLinkedToPost(true);
+
+        //when ( aaa.com 지우고 bbb.com, ddd.com 추가, ccc.com 은 그대로 )
+        imageService.afterUpdate(ImageType.NOTE, 3L, "<a> 하하하 </a> <p> 나는 p 에요 </p> <img src=\"https://bbb.com\"> <h1> 나는 제목이에요 </h1>"
+        +"<img src=\"https://ccc.com\"> <img src=\"https://ddd.com\">");
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1).isEqualTo(null);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getConnectedId()).isEqualTo(3L);
+        assertThat(tempImage2.getImageType()).isEqualTo(ImageType.NOTE);
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(true);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getConnectedId()).isEqualTo(3L);
+        assertThat(tempImage3.getImageType()).isEqualTo(ImageType.NOTE);
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(true);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getConnectedId()).isEqualTo(3L);
+        assertThat(tempImage4.getImageType()).isEqualTo(ImageType.NOTE);
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(true);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+
+    //3. 다이어리 / 일기의 삭제
+    @Test
+    void 커스텀이미지_다이어리_삭제(){
+        //given (다이어리 id 가 3이고 aaa.com 을 표지로 삼고 있음)
+        Image prevImage = imageRepository.findByImageUrl("https://aaa.com");
+        prevImage.changeImageType(ImageType.DIARY);
+        prevImage.changeConectedId(3L);
+        prevImage.changeLinkedToPost(true);
+
+        //when ( aaa.com 지우고 bbb.com, ddd.com 추가, ccc.com 은 그대로 )
+        imageService.afterDelete(ImageType.DIARY, 3L);
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1).isEqualTo(null);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 기본이미지_다이어리_삭제(){
+        //given
+
+        //when ( aaa.com 지우고 bbb.com, ddd.com 추가, ccc.com 은 그대로 )
+        imageService.afterDelete(ImageType.NOTE, 3L);
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 이미지있는_일기_삭제(){
+        //given (다이어리 id 가 3이고 aaa.com 을 표지로 삼고 있음)
+        Image prevImage = imageRepository.findByImageUrl("https://aaa.com");
+        prevImage.changeImageType(ImageType.NOTE);
+        prevImage.changeConectedId(3L);
+        prevImage.changeLinkedToPost(true);
+
+        //when ( aaa.com 지우고 bbb.com, ddd.com 추가, ccc.com 은 그대로 )
+        imageService.afterDelete(ImageType.NOTE, 3L);
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1).isEqualTo(null);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+    @Test
+    void 이미지없는_일기_삭제(){
+        //given (다이어리 id 가 3이고 aaa.com 을 표지로 삼고 있음)
+
+        //when ( aaa.com 지우고 bbb.com, ddd.com 추가, ccc.com 은 그대로 )
+        imageService.afterDelete(ImageType.DIARY, 3L);
+
+        //then
+        Image tempImage1 = imageRepository.findByImageUrl("https://aaa.com");
+        assertThat(tempImage1.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage2 = imageRepository.findByImageUrl("https://bbb.com");
+        assertThat(tempImage2.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage3 = imageRepository.findByImageUrl("https://ccc.com");
+        assertThat(tempImage3.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage4 = imageRepository.findByImageUrl("https://ddd.com");
+        assertThat(tempImage4.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage5 = imageRepository.findByImageUrl("https://eee.com");
+        assertThat(tempImage5.getIsLinkedToPost()).isEqualTo(false);
+
+        Image tempImage6 = imageRepository.findByImageUrl("https://kr.object.ncloudstorage.com/woozuda-image/random-image/random-image-3.jpg");
+        assertThat(tempImage6).isEqualTo(null);
+    }
+
+}

--- a/src/test/java/com/woozuda/backend/image/MakeImgsUrlTest.java
+++ b/src/test/java/com/woozuda/backend/image/MakeImgsUrlTest.java
@@ -1,0 +1,51 @@
+package com.woozuda.backend.image;
+
+import com.woozuda.backend.image.config.S3Client;
+import com.woozuda.backend.image.repository.ImageRepository;
+import com.woozuda.backend.image.service.ImageService;
+import com.woozuda.backend.image.type.ImageType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+public class MakeImgsUrlTest {
+
+    @InjectMocks
+    ImageService imageService;
+
+    @Mock
+    S3Client s3Client;
+
+    @Mock
+    ImageRepository imageRepository;
+
+    @Test
+    public void imageUrl_파서_테스트_노트()  {
+        List<String> urls= imageService.makeImgsUrl(ImageType.NOTE, "<p> 나는 </p> <h1> 운동을 했다 </h1> <img src = \"https://aaa.com\"> " +
+                "<p> 나는 </p> <h1> 잠을 잤다 </h1> <img src = \"https://bbb.com\">");
+
+        assertThat(urls).contains("https://aaa.com", "https://bbb.com");
+    }
+
+    @Test
+    public void imageUrl_파서_테스트_노트_없을때()  {
+        List<String> urls= imageService.makeImgsUrl(ImageType.NOTE, "<p> 나는 </p> <h1> 운동을 했다 </h1>" +
+                "<p> 나는 </p> <h1> 잠을 잤다 </h1>");
+
+        assertThat(urls).isEmpty();
+    }
+
+    @Test
+    public void imageUrl_파서_테스트_다이어리()  {
+        List<String> urls= imageService.makeImgsUrl(ImageType.DIARY, "https://aaa.com");
+
+        assertThat(urls).contains("https://aaa.com");
+    }
+}


### PR DESCRIPTION
예전에는 image 올린 후 삭제 로직이 없었습니다.

그래서
(1) 다이어리 / 일기에 잠깐 올리고 지운 이미지
(2) 다이어리 / 일기에 수정하면서 지운 이미지
가 대응될 수 있게 로직을 수정하였습니다.